### PR TITLE
AmQStrTdcSamplerのメモリーリーク修正

### DIFF
--- a/AmQStrTdcSampler.cxx
+++ b/AmQStrTdcSampler.cxx
@@ -4,7 +4,6 @@
 #include <iostream>
 
 #include "utility/MessageUtil.h"
-#include "utility/Reporter.h"
 #include "AmQStrTdcSampler.h"
 
 #include "utility/network.hh"
@@ -73,7 +72,6 @@ bool AmQStrTdcSampler::ConditionalRun()
   
   //    while (Send(msg, "data") == -2);
 
-  Reporter::AddOutputMessageSize(msg->GetSize());
   Send(msg, fOutputChannelName);
 
   //     ++fNumIterations;
@@ -95,7 +93,6 @@ bool AmQStrTdcSampler::ConditionalRun()
 //______________________________________________________________________________
 void AmQStrTdcSampler::Init()
 {
-  Reporter::Instance(fConfig);
 }
 //_____________________________________________________________________________
 void AmQStrTdcSampler::SendFEMInfo()
@@ -205,7 +202,6 @@ void AmQStrTdcSampler::InitTask()
   FPGAModule fModule(fIpSiTCP.c_str(), 4660, &rbcpHeader, 0);
   LOG(info) << std::hex << fModule.ReadModule(hul_strtdc::BCT::addr_Version, 4) << std::dec;
   */
-  Reporter::Reset();
 }
 
 //______________________________________________________________________________

--- a/AmQStrTdcSampler.cxx
+++ b/AmQStrTdcSampler.cxx
@@ -45,7 +45,10 @@ bool AmQStrTdcSampler::ConditionalRun()
     }// For(i)
   }
 
-  if (n_word<=0) return true;
+  if (n_word<=0){
+    delete[] buffer; 
+    return true;
+  }
   
   if(fTdcType == 1){
     //    auto data5 = reinterpret_cast<lrWord*>(buffer);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ target_link_directories(AmQStrTdcSampler PUBLIC
 )
 
 target_link_libraries(AmQStrTdcSampler  PUBLIC
+                        ${fmt_LIB};
                         FairMQ;
                         FairLogger;
                         ${Boost_LIBRARIES};

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -89,6 +89,8 @@ endif()
 
 target_include_directories(Utility PRIVATE
   ${Boost_INCLUDE_DIRS};
+  ${FairLogger_INCDIR};
+  ${FairMQ_INCDIR};
   ${YAML_CPP_INCLUDE_DIR};
   ${CMAKE_SOURCE_DIR};
 )
@@ -99,7 +101,10 @@ target_link_directories(Utility PRIVATE
 
 target_link_libraries(Utility
   ${Boost_LIBRARIES};
-  ${YAML_CPP_LIBRARIES}
+  ${YAML_CPP_LIBRARIES};
+  ${fmt_LIB};
+  ${FairLogger_LIBDIR};
+  ${FairMQ_LIBDIR};
 )
 
 


### PR DESCRIPTION
- `buffer`が `n_word<=0`でdeleteし忘れているのを修正
- Reporterを削除