### PR TITLE
close #15/ Changes: No more need to configure the number of source for TimeFrameBuilder

### DIFF
--- a/AmQStrTdcDqm.cxx
+++ b/AmQStrTdcDqm.cxx
@@ -303,13 +303,13 @@ void AmQStrTdcDqm::InitServer(std::string_view server)
 void AmQStrTdcDqm::InitTask()
 {
   using opt = OptionKey;
-  fNumSource         = fConfig->GetValue<int>(opt::NumSource.data());
+  fNumSource         = fConfig->GetProperty<int>(opt::NumSource.data());
   assert(fNumSource>=1);
 
-  fBufferTimeoutInMs  = fConfig->GetValue<int>(opt::BufferTimeoutInMs.data());
-  fInputChannelName   = fConfig->GetValue<std::string>(opt::InputChannelName.data());
-  auto server         = fConfig->GetValue<std::string>(opt::Http.data());
-  fUpdateIntervalInMs = fConfig->GetValue<int>(opt::UpdateInterval.data());
+  fBufferTimeoutInMs  = fConfig->GetProperty<int>(opt::BufferTimeoutInMs.data());
+  fInputChannelName   = fConfig->GetProperty<std::string>(opt::InputChannelName.data());
+  auto server         = fConfig->GetProperty<std::string>(opt::Http.data());
+  fUpdateIntervalInMs = fConfig->GetProperty<int>(opt::UpdateInterval.data());
 
   fHbc.resize(fNumSource);
 

--- a/STFBuilder.cxx
+++ b/STFBuilder.cxx
@@ -381,7 +381,7 @@ void AmQStrTdcSTFBuilder::InitTask()
     // convert IP address  to 32 bit. e.g. 192.168.10.16 -> FEM id = 0xC0A80A10
     //    fFEMId = 0;
 
-    auto femid = fConfig->GetValue<std::string>(opt::FEMId.data());
+    auto femid = fConfig->GetProperty<std::string>(opt::FEMId.data());
     std::istringstream iss(femid);
     std::string token;
     int i = 3;
@@ -396,9 +396,9 @@ void AmQStrTdcSTFBuilder::InitTask()
   }
   */
 
-  fInputChannelName  = fConfig->GetValue<std::string>(opt::InputChannelName.data());
-  fOutputChannelName = fConfig->GetValue<std::string>(opt::OutputChannelName.data());
-  fDQMChannelName    = fConfig->GetValue<std::string>(opt::DQMChannelName.data());
+  fInputChannelName  = fConfig->GetProperty<std::string>(opt::InputChannelName.data());
+  fOutputChannelName = fConfig->GetProperty<std::string>(opt::OutputChannelName.data());
+  fDQMChannelName    = fConfig->GetProperty<std::string>(opt::DQMChannelName.data());
 
 
   //////
@@ -426,11 +426,11 @@ void AmQStrTdcSTFBuilder::InitTask()
   fFEMId = femID;
   fFEMType = femType;
 
-  auto s_maxHBF = fConfig->GetValue<std::string>(opt::MaxHBF.data());
+  auto s_maxHBF = fConfig->GetProperty<std::string>(opt::MaxHBF.data());
   fMaxHBF = std::stoi(s_maxHBF);
   LOG(debug) << "fMaxHBF = " <<fMaxHBF;
 
-  auto s_splitMethod = fConfig->GetValue<std::string>(opt::SplitMethod.data());
+  auto s_splitMethod = fConfig->GetProperty<std::string>(opt::SplitMethod.data());
   fSplitMethod = std::stoi(s_splitMethod);
 
   fSTFId      = 0;

--- a/Sampler.cxx
+++ b/Sampler.cxx
@@ -157,11 +157,11 @@ void Sampler::InitTask()
   }
 
   // for Modue IP Address
-  fIpSiTCP = fConfig->GetValue<std::string>(opt::IpSiTCP.data());
+  fIpSiTCP = fConfig->GetProperty<std::string>(opt::IpSiTCP.data());
   LOG(info) << "TPC IP: " << fIpSiTCP;
 
   // A flag for Sending the FEM info or not
-  auto flag = fConfig->GetValue<std::string>(opt::SendInfo.data());
+  auto flag = fConfig->GetProperty<std::string>(opt::SendInfo.data());
   int nflag = stoi(flag);
   LOG(info) << "nflag: " << nflag;
  

--- a/TimeFrameBuilder.cxx
+++ b/TimeFrameBuilder.cxx
@@ -161,12 +161,15 @@ void TimeFrameBuilder::Init()
 void TimeFrameBuilder::InitTask()
 {
   using opt = OptionKey;
-  auto sNumSource         = fConfig->GetValue<std::string>(opt::NumSource.data());
-  fNumSource         = std::stoi(sNumSource);
-  auto sBufferTimeoutInMs = fConfig->GetValue<std::string>(opt::BufferTimeoutInMs.data());
+  auto sBufferTimeoutInMs = fConfig->GetProperty<std::string>(opt::BufferTimeoutInMs.data());
   fBufferTimeoutInMs = std::stoi(sBufferTimeoutInMs);
-  fInputChannelName  = fConfig->GetValue<std::string>(opt::InputChannelName.data());
-  fOutputChannelName = fConfig->GetValue<std::string>(opt::OutputChannelName.data());
+  fInputChannelName  = fConfig->GetProperty<std::string>(opt::InputChannelName.data());
+  fOutputChannelName = fConfig->GetProperty<std::string>(opt::OutputChannelName.data());
+  auto numSubChannels = GetNumSubChannels(fInputChannelName);
+  fNumSource = 0;
+  for (auto i=0; i<numSubChannels; ++i) {
+    fNumSource += GetNumberOfConnectedPeers(fInputChannelName, i);
+  }
 
   LOG(debug) << " input channel : name = " << fInputChannelName 
 	     << " num = " << GetNumSubChannels(fInputChannelName)
@@ -216,7 +219,6 @@ void addCustomOptions(bpo::options_description& options)
 {
   using opt = TimeFrameBuilder::OptionKey;
   options.add_options()
-    (opt::NumSource.data(),         bpo::value<std::string>()->default_value("2"),             "Number of source endpoint")
     (opt::BufferTimeoutInMs.data(), bpo::value<std::string>()->default_value("100000"),        "Buffer timeout in milliseconds")
     (opt::InputChannelName.data(),  bpo::value<std::string>()->default_value("in"),  "Name of the input channel")
     (opt::OutputChannelName.data(), bpo::value<std::string>()->default_value("out"), "Name of the output channel")


### PR DESCRIPTION
- close #15
- Changes: 
  - No more need to configure the number of source for TimeFrameBuilder. The value is calculated by using GetNumberOfConnectedPeers()

