### PR TITLE
remove sleep in Sampler::ConditinalRun().

### DIFF
--- a/Sampler.cxx
+++ b/Sampler.cxx
@@ -231,8 +231,6 @@ bool Sampler::ConditionalRun()
     }
   }
 
-  sleep(1);
-
   FairMQMessagePtr msg( NewMessage((char*)buffer,
 				   //				  fnByte*nword
 				  nByteSize,


### PR DESCRIPTION
ConditionalRun()を使っている場合、`rate` というパラメータ (コマンドライン or redis経由)でsleep間隔を指定できるので、Sampler::ConditionalRun()の中のsleep(1)を削除しました