### PR TITLE
update AmQStrTdcSampler and STFBuilder

### DIFF
--- a/AmQStrTdcSampler.cxx
+++ b/AmQStrTdcSampler.cxx
@@ -325,7 +325,7 @@ int AmQStrTdcSampler::Event_Cycle(uint8_t* buffer)
     //  static const unsigned int sizeData = fnByte*fnWordPerCycle*sizeof(uint8_t);
     static const unsigned int sizeData = optnByte*fnWordPerCycle*sizeof(uint8_t);
     int ret = receive(fAmqSocket, (char*)buffer, sizeData);
-    if(ret < 0) return ret;
+    if(ret <= 0) return ret;
 
     return fnWordPerCycle;
 }

--- a/STFBuilder.cxx
+++ b/STFBuilder.cxx
@@ -209,9 +209,9 @@ AmQStrTdcSTFBuilder::FillData(AmQStrTdc::Data::Word* first,
         }
     }
 
-    if (!isSpillEnd) {
+    //if (!isSpillEnd) {
         fWorkingPayloads->emplace_back(NewSimpleMessage(*last));
-    }
+    //}
 
 }
 


### PR DESCRIPTION
- ignore isSpillEnd flag in STFBuilder::FillData()
- 0 is allowed for the return value of AmQStrTdcSampler::Event_Cycle() to exit while-loop in PostRun()